### PR TITLE
receipt-api/17 get backend endpoint hit too many times

### DIFF
--- a/receipt-frontend/src/components/ReceiptPointsModal.tsx
+++ b/receipt-frontend/src/components/ReceiptPointsModal.tsx
@@ -31,7 +31,7 @@ const ReceiptPointsModal: FC<ReceiptPointsModalProps> = ({
   const [accruedReceiptPoints, setAccruedReceiptPoints] =
     useState<string>("");
 
-  useEffect(() => {
+  if (!accruedReceiptPoints) {
     FetchRewards.getReceiptPoints(receiptId).then(
       (receiptPoints) => {
         setAccruedReceiptPoints(receiptPoints.points);
@@ -42,7 +42,7 @@ const ReceiptPointsModal: FC<ReceiptPointsModalProps> = ({
         );
       }
     );
-  });
+  }
 
   return (
     <>

--- a/receipt-frontend/src/components/ReceiptPointsModal.tsx
+++ b/receipt-frontend/src/components/ReceiptPointsModal.tsx
@@ -1,5 +1,5 @@
 import { Box, Divider, Fade, Modal, Typography } from "@mui/material";
-import { FC, useEffect, useState } from "react";
+import { FC, useState } from "react";
 import FetchRewards from "../api/fetchRewards";
 import Receipt from "../model/receipt";
 


### PR DESCRIPTION
Small PR that removes the `useEffect` from the `ReceiptPointsModal` component, reducing the number of API calls to the backend when fetching receipt points accrued by id.

Thos PR addresses issue #17 