### PR TITLE
receipt-api/23 add tooltip to edit button for receipt items

### DIFF
--- a/receipt-frontend/src/components/PurchasedItem.tsx
+++ b/receipt-frontend/src/components/PurchasedItem.tsx
@@ -5,6 +5,7 @@ import {
   Button,
   IconButton,
   TextField,
+  Tooltip,
   Typography,
 } from "@mui/material";
 import { ReceiptItem } from "../model/receipt";
@@ -106,13 +107,15 @@ const PurchasedItem: FC<PurchasedItemProps> = ({
           value={itemPrice}
           onChange={(e) => setItemPrice(e.target.value)}
         />
-        <IconButton
-          aria-label="edit-item"
-          disabled={!receiptItem}
-          onClick={handleEditItemClick}
-        >
-          <EditIcon />
-        </IconButton>
+        <Tooltip title="Click to edit this item, click again to submit your changes">
+          <IconButton
+            aria-label="edit-item"
+            disabled={!receiptItem}
+            onClick={handleEditItemClick}
+          >
+            <EditIcon />
+          </IconButton>
+        </Tooltip>
       </Box>
       {!receiptItem && (
         <Button


### PR DESCRIPTION
Small PR that adds a tooltip to the edit button for receipt items, hoping this brings a slightly better UX

This PR addresses issue #23 